### PR TITLE
fix sqlite analyze too slow issue when db is too big

### DIFF
--- a/writer.js
+++ b/writer.js
@@ -528,6 +528,8 @@ function updateSqliteStats(){
 		return;
 	db.query("SELECT MAX(rowid) AS count_units FROM units", function(rows){
 		var count_units = rows[0].count_units;
+		if (count_units > 500000) // the db is too big, anaylze will lock db for long time,skip it from now on.
+			return;
 		readCountOfAnalyzedUnits(function(count_analyzed_units){
 			console.log('count analyzed units: '+count_analyzed_units);
 			if (count_units < 2*count_analyzed_units)


### PR DESCRIPTION
when db is too big, sqlite analyze cmd will be running for long time while blocking other db access.  fix it when db size exceed threshold .